### PR TITLE
Change verbosity to a count

### DIFF
--- a/README.md
+++ b/README.md
@@ -54,7 +54,7 @@ Options
 * `-d`, `--daily`: Organize photos into daily folders (year/month/day)
 * `-e`, `--endings`: Specify file endings/extensions to copy (e.g., .jpg .png). If not specified, all files are included
 * `--exclude`: Provide a regex pattern to exclude matching files from being processed
-* `-v`, `--verbose`: Enable verbose logging
+* `-v`, `--verbose`: Enable verbose logging. -vv means more verbose.
 * `-c`, `--copy`: Copy files instead of moving them
 * `--no-year`: Do not place month folders inside a year folder; place them top-level with the name format YEAR-MONTH
 
@@ -82,7 +82,7 @@ photo-organizer /path/to/source /path/to/target --exclude "^ignore|\.tmp$"
 
 Enable verbose logging:
 ```bash
-photo_organizer /path/to/source /path/to/target -v
+photo_organizer /path/to/source /path/to/target -vv
 ```
 
 Move photos to top-level year-month folders without a year parent folder:
@@ -92,7 +92,7 @@ photo-organizer --no-year /path/to/source /path/to/target
 
 Combine options to copy .jpg and .png files recursively into daily folders with verbose logging:
 ```bash
-photo-organizer -r -d -e .jpg .png -v -c /path/to/source /path/to/target
+photo-organizer -r -d -e .jpg .png -vv -c /path/to/source /path/to/target
 ```
 
 ## Development
@@ -106,7 +106,7 @@ To contribute to this project, follow these steps:
 
 ## Logging
 
-The script uses Python's logging module to provide detailed information about the operations performed. By default, the logging level is set to INFO. Use the `-v` or `--verbose` flag to enable `DEBUG` level logging for more detailed output.
+The script uses Python's logging module to provide detailed information about the operations performed. By default, the logging level is set to INFO. Use the `-v` or `--verbose` flag to enable `INFO` level logging and `-v` or `--verbose --verbose`` for `DEBUG` level logging for more detailed output.
 
 ## Contributing
 

--- a/photo_organizer/main.py
+++ b/photo_organizer/main.py
@@ -111,7 +111,7 @@ def configure_logging(verbose):
     Configure logging settings.
 
     Parameters:
-    verbose (bool): If True, enable verbose logging.
+    verbose (int): Increase verbosity with count (max of 2).
     """
     if verbose == 0:
         level = logging.WARNING  # default

--- a/photo_organizer/main.py
+++ b/photo_organizer/main.py
@@ -113,8 +113,18 @@ def configure_logging(verbose):
     Parameters:
     verbose (bool): If True, enable verbose logging.
     """
+    if verbose == 0:
+        level = logging.WARNING  # default
+    elif verbose == 1:
+        level = logging.INFO
+    elif verbose == 2:
+        level = logging.DEBUG
+    elif verbose > 2:
+        level = logging.DEBUG
+        logging.warning("Verbosity set >2 has no effect.")
+
     logging.basicConfig(
-        level=logging.DEBUG if verbose else logging.INFO,
+        level=level,
         format="%(asctime)s - %(levelname)s - %(message)s",
     )
 
@@ -149,7 +159,11 @@ def parse_arguments():
         help="File endings/extensions to copy (e.g., .jpg .png)",
     )
     parser.add_argument(
-        "-v", "--verbose", action="store_true", help="Enable verbose logging"
+        "-v",
+        "--verbose",
+        action="count",
+        default=0,
+        help="Increase verbosity level (use -v for verbose, -vv for more verbose).",
     )
     parser.add_argument(
         "-c", "--copy", action="store_true", help="Copy files instead of moving them"

--- a/tests/test_main_integration.py
+++ b/tests/test_main_integration.py
@@ -24,7 +24,7 @@ def mock_args(base, **overrides):
         recursive = False
         endings = [".jpg", ".png"]
         exclude = None
-        verbose = False
+        verbose = 0
         exclude_regex = False
 
     for key, value in overrides.items():

--- a/tests/test_main_unit.py
+++ b/tests/test_main_unit.py
@@ -16,7 +16,7 @@ def mock_args():
         copy=False,
         no_year=False,
         daily=False,
-        verbose=False,
+        verbose=0,
     )
 
 


### PR DESCRIPTION
By changing the verbosity to a count one can specify more than two levels of verbosity.

This is specifically helpful as the default logging level (in this request) is WARNING so the user will only be prompted if a file is not successfully moved or another error occurs, as I believe should be the default.

A single verbosity flag `-v` or `--verbose` changes the logging level from WARNING to INFO, which was the default behaviour before. A second instance of this flag `-vv` or `--verbose --verbose` changes the level to DEBUG.

Additionally the documentation in the readme was updated and the unit tests updated too.
