### PR TITLE
Print the file name that has a problem when using EXIF

### DIFF
--- a/photo_organizer/main.py
+++ b/photo_organizer/main.py
@@ -419,9 +419,7 @@ def organize_files(
             failed_files.append(file_path)
         finally:
             # Update directory counts for progress reporting
-            if no_progress:
-                continue
-            if os.path.exists(target_path):
+            if not no_progress and os.path.exists(target_path):
                 directory_counts[target_folder] = directory_counts.get(target_folder, 0) + 1
 
     # Show progress summary


### PR DESCRIPTION
When parsing through the files and using EXIF to extract the date, you might hit a file that has a problem. The message that appears doesn't tell you which file that is, leaving me to guess later which file ended up in the wrong location. It would be helpful .

Before:

```
2025-12-19 07:44:12,591 - WARNING - File format not recognized.
2025-12-19 07:44:12,593 - WARNING - Invalid EXIF date format: None. Falling back to file system.
```

After:

```
2025-12-19 07:43:08,436 - WARNING - File format not recognized.
2025-12-19 07:43:08,439 - WARNING - Invalid EXIF date format: None for /Volumes/Base/photo-staging/2025/12/MVI_5969.MP4. Falling back to file system.
```

Thanks